### PR TITLE
Minor fixes for sending UserName

### DIFF
--- a/Client/MainWindow.xaml.cs
+++ b/Client/MainWindow.xaml.cs
@@ -20,8 +20,8 @@ namespace Client
         public MainWindow(string userName)
         {
             InitializeComponent();
-            InitializeServerConnection();
             UserName = userName;
+            InitializeServerConnection();
         }
 
         #region Private Members
@@ -226,7 +226,7 @@ namespace Client
                     // InitializeComponent a new message for logoff
                     Message sendData = new Message
                     {
-                        Who = "Me",
+                        Who = UserName,
                         What = "",
                         When = DateTime.Now.ToShortTimeString(),
                         Where = 0, // Default Chat Room


### PR DESCRIPTION
Fix for client not sending UserName in login message
-(UserName was defined after the server connection/login)

Changed the logoff message to include username